### PR TITLE
Rename `datasets` to `hits` in `BackendSearchResponse`

### DIFF
--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -74,7 +74,7 @@ export const SearchPage = () => {
         );
     }
 
-    const datasets = results?.datasets || [];
+    const datasets = results?.hits || [];
     const summary = results?.summary || '';
 
     return (

--- a/src/types/zenodo.ts
+++ b/src/types/zenodo.ts
@@ -11,7 +11,7 @@ export interface BackendDataset {
 }
 
 export interface BackendSearchResponse {
-    datasets: BackendDataset[];
+    hits: BackendDataset[];
     summary: string;
 }
 


### PR DESCRIPTION
This pull request updates the naming of the datasets field in the search response to improve consistency across the codebase.