### PR TITLE
Add Matomo for Data Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 /.env
 /builder.config.json
 /tsconfig.tsbuildinfo
+/keys.env

--- a/docker-compose-data-analytics.yml
+++ b/docker-compose-data-analytics.yml
@@ -1,0 +1,34 @@
+services:
+  db:
+    image: mariadb:10.6
+    container_name: matomo-db
+    restart: always
+    networks:
+      - matomo-net
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: matomo
+      MYSQL_USER: matomo
+      MYSQL_PASSWORD: matomo_password
+    volumes:
+      - matomo-db-data:/var/lib/mysql
+
+  matomo:
+    image: matomo:latest
+    container_name: matomo
+    restart: always
+    depends_on:
+      - db
+    networks:
+      - matomo-net
+    ports:
+      - "8080:80"
+    volumes:
+      - matomo-data:/var/www/html
+
+networks:
+  matomo-net:
+
+volumes:
+  matomo-db-data:
+  matomo-data:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {BrowserRouter, Routes, Route} from "react-router-dom";
 import {LandingPage} from "./pages/LandingPage";
 import {SearchPage} from "./pages/SearchPage";
@@ -5,7 +6,24 @@ import NotFound from "./pages/NotFound";
 import {ErrorBoundary} from "./components/ErrorBoundary";
 
 
+declare global {
+    interface Window {
+        _mtm: Record<string, unknown>[];
+    }
+}
+
 export default function App() {
+    React.useEffect(() => {
+        window._mtm = window._mtm || [];
+        window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+        const d = document;
+        const g = d.createElement('script');
+        const s = d.getElementsByTagName('script')[0];
+        g.async = true;
+        g.src = 'http://localhost:8080/js/container_mvwg2URH.js'; // <-- Replace with your actual container URL
+        s.parentNode!.insertBefore(g, s);
+    }, []);
+
     return (
         <BrowserRouter>
             <ErrorBoundary>


### PR DESCRIPTION
This pull request introduces Matomo analytics integration into the project. It adds a new Docker Compose configuration to run Matomo and its database locally, and updates the React application to load the Matomo tracking script when the app starts.